### PR TITLE
Fix Airbnb peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "eslint-config-20minutes",
   "version": "1.0.4",
   "peerDependencies": {
-    "eslint-config-airbnb": "^16.0.0"
+    "eslint-config-airbnb": ">16.0.0"
   }
 }


### PR DESCRIPTION
They jump too fast in their versioning. So instead of targetting a major version, we just need at least a version.
It'll avoid this kind of warning:

> warning " > eslint-config-20minutes@1.0.4" has incorrect peer dependency "eslint-config-airbnb@^16.0.0".