### PR TITLE
Use @babel/eslint-parser instead of babel-eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 package-lock.json
+yarn.lock
 node_modules/*

--- a/index.js
+++ b/index.js
@@ -5,7 +5,10 @@ module.exports = {
     jest: true,
     browser: true,
   },
-  parser: 'babel-eslint',
+  parser: '@babel/eslint-parser',
+  parserOptions: {
+    requireConfigFile: false,
+  },
   extends: 'airbnb',
   plugins: [
     'babel',

--- a/package.json
+++ b/package.json
@@ -4,14 +4,15 @@
   "description": "ESLint shareable config for 20 Minutes",
   "license": "MIT",
   "devDependencies": {
-    "babel-eslint": "^10.0",
+    "@babel/core": "^7.13.0",
+    "@babel/eslint-parser": "^7.13.0",
+    "eslint": "^7.20.0",
+    "eslint-config-airbnb": ">=16.0.0",
     "eslint-plugin-babel": "^5.0",
-    "eslint": "^5.16.0 || ^6.8.0 || ^7.3.1",
     "eslint-plugin-import": "^2.21.2",
-    "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-jsx-a11y": "^6.3.0",
-    "eslint-plugin-react-hooks": "^1.7.0 || ^2.3.0 || ^3 || ^4",
-    "eslint-config-airbnb": ">=16.0.0"
+    "eslint-plugin-react": "^7.20.0",
+    "eslint-plugin-react-hooks": "^1.7.0 || ^2.3.0 || ^3 || ^4"
   },
   "peerDependencies": {
     "eslint-config-airbnb": ">=16.0.0"


### PR DESCRIPTION
`babel-eslint` is deprecated since July 2020 https://github.com/babel/babel-eslint/pull/842